### PR TITLE
Put byte array with larger size into buffer pool

### DIFF
--- a/core/buffer_pool.go
+++ b/core/buffer_pool.go
@@ -21,7 +21,7 @@ func NewBytes(size int) []byte {
 }
 
 func FreeBytes(b []byte) {
-	if len(b) <= BufSize {
+	if len(b) >= BufSize {
 		pool.Put(b)
 	}
 }


### PR DESCRIPTION
If the size of buffer is less than BufSize, it will break the contract that NewBytes returns []byte with at least BufSize. 