### PR TITLE
UDP connection handler for DNS/TCP fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOCLEAN=$(GOCMD) clean
 VERSION=$(shell git describe --tags)
 DEBUG_LDFLAGS=''
 RELEASE_LDFLAGS='-s -w -X main.version=$(VERSION)'
-BUILD_TAGS=dns socks shadowsocks v2ray redirect echo
+BUILD_TAGS?=dns socks shadowsocks v2ray redirect echo
 DEBUG_BUILD_TAGS=$(BUILD_TAGS) debug
 BUILDDIR=$(shell pwd)/build
 CMDDIR=$(shell pwd)/cmd/tun2socks

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOCLEAN=$(GOCMD) clean
 VERSION=$(shell git describe --tags)
 DEBUG_LDFLAGS=''
 RELEASE_LDFLAGS='-s -w -X main.version=$(VERSION)'
-BUILD_TAGS?=dns socks shadowsocks v2ray redirect echo
+BUILD_TAGS?=dns socks shadowsocks v2ray redirect echo dnsfallback
 DEBUG_BUILD_TAGS=$(BUILD_TAGS) debug
 BUILDDIR=$(shell pwd)/build
 CMDDIR=$(shell pwd)/cmd/tun2socks

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ ls ./build
 
 ### Customizing Build
 
-The default build behavior is to include all available modules, ends up a fat binary that will contain modules you may not need. It's easy to customize the build to include only modules you want by modifying the `Makefile`, for example, you may build `go-tun2socks` with only the `socks` proxy handler by changing [this line](https://github.com/eycorsican/go-tun2socks/blob/45ac13fd65286a964689cbfcba959405961cea45/Makefile#L8):
+The default build behavior is to include all available modules, ends up a fat binary that will contain modules you may not need. It's easy to customize the build to include only modules you want by modifying the `Makefile`, for example, you may build `go-tun2socks` with only the `socks` proxy handler by setting the `BUILD_TAGS` variable before calling `make`:
 ```
 # socks handler only
-BUILD_TAGS=socks
+BUILD_TAGS=socks make
 
 # socks handler with DNS cache
-BUILD_TAGS=socks dns
+BUILD_TAGS=socks dns make
 ```
 
 ## Run

--- a/cmd/tun2socks/main.go
+++ b/cmd/tun2socks/main.go
@@ -51,6 +51,7 @@ type CmdArgs struct {
 	UdpTimeout      *time.Duration
 	Applog          *bool
 	DisableDnsCache *bool
+	DnsFallback     *bool
 }
 
 type cmdFlag uint
@@ -148,6 +149,15 @@ func main() {
 		creater()
 	} else {
 		log.Fatal("unsupported proxy type")
+	}
+
+	if *args.DnsFallback {
+		// Override the UDP handler with a DNS-over-TCP (fallback) UDP handler.
+		if creater, found := handlerCreater["dnsfallback"]; found {
+			creater()
+		} else {
+			log.Fatal("DNS fallback connection handler not found, build with `dnsfallback` tag")
+		}
 	}
 
 	// Register an output callback to write packets output from lwip stack to tun

--- a/cmd/tun2socks/main_dns_fallback.go
+++ b/cmd/tun2socks/main_dns_fallback.go
@@ -1,0 +1,18 @@
+// +build dnsfallback
+
+package main
+
+import (
+	"flag"
+
+	"github.com/eycorsican/go-tun2socks/core"
+	"github.com/eycorsican/go-tun2socks/proxy/dnsfallback"
+)
+
+func init() {
+	args.DnsFallback = flag.Bool("dnsFallback", false, "Enable DNS fallback over TCP (overrides the UDP proxy handler).")
+
+	registerHandlerCreater("dnsfallback", func() {
+		core.RegisterUDPConnHandler(dnsfallback.NewUDPHandler())
+	})
+}

--- a/proxy/dnsfallback/udp.go
+++ b/proxy/dnsfallback/udp.go
@@ -1,0 +1,64 @@
+package dnsfallback
+
+import (
+	"errors"
+	"net"
+
+	"github.com/eycorsican/go-tun2socks/common/dns"
+	"github.com/eycorsican/go-tun2socks/core"
+)
+
+// UDP handler that intercepts DNS queries and replies with a truncated response (TC bit)
+// in order for the client to retry over TCP. This DNS/TCP fallback mechanism is
+// useful for proxy servers that do not support UDP.
+// Note that non-DNS UDP traffic is dropped.
+type udpHandler struct{}
+
+const (
+	dnsHeaderLength = 12
+	dnsMaskQr       = uint8(0x80)
+	dnsMaskTc       = uint8(0x02)
+	dnsMaskRcode    = uint8(0x0F)
+)
+
+func NewUDPHandler() core.UDPConnHandler {
+	return &udpHandler{}
+}
+
+func (h *udpHandler) Connect(conn core.UDPConn, target net.Addr) error {
+	udpAddr, ok := target.(*net.UDPAddr)
+	if !ok {
+		return errors.New("Unsupported address type")
+	}
+	if udpAddr.Port != dns.COMMON_DNS_PORT {
+		return errors.New("Cannot handle non-DNS packet")
+	}
+	return nil
+}
+
+func (h *udpHandler) DidReceiveTo(conn core.UDPConn, data []byte, addr net.Addr) error {
+	if len(data) < dnsHeaderLength {
+		return errors.New("Received malformed DNS query")
+	}
+	//  DNS Header
+	//  0  1  2  3  4  5  6  7  0  1  2  3  4  5  6  7
+	//  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+	//  |                      ID                       |
+	//  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+	//  |QR|   Opcode  |AA|TC|RD|RA|   Z    |   RCODE   |
+	//  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+	//  |                    QDCOUNT                    |
+	//  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+	//  |                    ANCOUNT                    |
+	//  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+	//  |                    NSCOUNT                    |
+	//  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+	//  |                    ARCOUNT                    |
+	//  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+	// Set response and truncated bits
+	data[2] |= dnsMaskQr | dnsMaskTc
+	// Set response code to 'no error'.
+	data[3] &= ^dnsMaskRcode
+	_, err := conn.WriteFrom(data, addr)
+	return err
+}


### PR DESCRIPTION
* Implements a UDP connection handler that responds to DNS queries with a truncated bit in order for the query to be retried over TCP.
  * This is useful for servers that do not support UDP, and/or networks that block UDP traffic to non-standard ports.
  * While TCP support is advisory in DNS resolvers, we have found that major resolvers support it in practice. Additionally, DNS clients in all major operating systems support the retry behavior when receiving a truncated response.
  * See [RFC 1123, section 6.1.3.2](https://tools.ietf.org/html/rfc1123#page-75) for more details.
* Exposes a flag `-dnsFallback` to enable this behavior by overriding the specified UDP proxy handler.
* Builds the module when "dnsfallback" is present in `$BUILD_TAGS`.
* Sets a default value for `$BUILD_TGAS`, so it can be customized from the command line.