### PR TITLE
Use more specific address types

### DIFF
--- a/core/addr.go
+++ b/core/addr.go
@@ -29,7 +29,7 @@ func ipAddrATON(cp string, addr *C.struct_ip_addr) error {
 	}
 }
 
-func ParseTCPAddr(addr string, port uint16) net.Addr {
+func ParseTCPAddr(addr string, port uint16) *net.TCPAddr {
 	netAddr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(addr, strconv.Itoa(int(port))))
 	if err != nil {
 		return nil
@@ -37,7 +37,7 @@ func ParseTCPAddr(addr string, port uint16) net.Addr {
 	return netAddr
 }
 
-func ParseUDPAddr(addr string, port uint16) net.Addr {
+func ParseUDPAddr(addr string, port uint16) *net.UDPAddr {
 	netAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(addr, strconv.Itoa(int(port))))
 	if err != nil {
 		return nil

--- a/core/conn.go
+++ b/core/conn.go
@@ -67,15 +67,15 @@ type TCPConn interface {
 // should be handled by a registered UDP proxy handler.
 type UDPConn interface {
 	// LocalAddr returns the local client network address.
-	LocalAddr() net.Addr
+	LocalAddr() *net.UDPAddr
 
 	// ReceiveTo will be called when data arrives from TUN, and the received
 	// data should be sent to addr.
-	ReceiveTo(data []byte, addr net.Addr) error
+	ReceiveTo(data []byte, addr *net.UDPAddr) error
 
 	// WriteFrom writes data to TUN, addr will be set as source address of
 	// UDP packets that output to TUN.
-	WriteFrom(data []byte, addr net.Addr) (int, error)
+	WriteFrom(data []byte, addr *net.UDPAddr) (int, error)
 
 	// Close closes the connection.
 	Close() error

--- a/core/handler.go
+++ b/core/handler.go
@@ -7,16 +7,16 @@ import (
 // TCPConnHandler handles TCP connections comming from TUN.
 type TCPConnHandler interface {
 	// Handle handles the conn for target.
-	Handle(conn net.Conn, target net.Addr) error
+	Handle(conn net.Conn, target *net.TCPAddr) error
 }
 
 // UDPConnHandler handles UDP connections comming from TUN.
 type UDPConnHandler interface {
 	// Connect connects the proxy server. Note that target can be nil.
-	Connect(conn UDPConn, target net.Addr) error
+	Connect(conn UDPConn, target *net.UDPAddr) error
 
 	// ReceiveTo will be called when data arrives from TUN.
-	ReceiveTo(conn UDPConn, data []byte, addr net.Addr) error
+	ReceiveTo(conn UDPConn, data []byte, addr *net.UDPAddr) error
 }
 
 var tcpConnHandler TCPConnHandler

--- a/core/tcp_conn.go
+++ b/core/tcp_conn.go
@@ -60,8 +60,8 @@ type tcpConn struct {
 
 	pcb           *C.struct_tcp_pcb
 	handler       TCPConnHandler
-	remoteAddr    net.Addr
-	localAddr     net.Addr
+	remoteAddr    *net.TCPAddr
+	localAddr     *net.TCPAddr
 	connKeyArg    unsafe.Pointer
 	connKey       uint32
 	canWrite      *sync.Cond // Condition variable to implement TCP backpressure.
@@ -109,7 +109,7 @@ func newTCPConn(pcb *C.struct_tcp_pcb, handler TCPConnHandler) (TCPConn, error) 
 	conn.state = tcpConnecting
 	conn.Unlock()
 	go func() {
-		err := handler.Handle(TCPConn(conn), conn.RemoteAddr())
+		err := handler.Handle(TCPConn(conn), conn.remoteAddr)
 		if err != nil {
 			conn.Abort()
 		} else {

--- a/proxy/d/tcp.go
+++ b/proxy/d/tcp.go
@@ -70,7 +70,7 @@ func (h *tcpHandler) relay(lhs, rhs net.Conn) {
 	cls()
 }
 
-func (h *tcpHandler) Handle(conn net.Conn, target net.Addr) error {
+func (h *tcpHandler) Handle(conn net.Conn, target *net.TCPAddr) error {
 	localHost, localPortStr, _ := net.SplitHostPort(conn.LocalAddr().String())
 	localPortInt, _ := strconv.Atoi(localPortStr)
 	cmd, err := lsof.GetCommandNameBySocket("tcp", localHost, uint16(localPortInt))

--- a/proxy/d/udp.go
+++ b/proxy/d/udp.go
@@ -40,7 +40,7 @@ func NewUDPHandler(proxyHandler core.UDPConnHandler, exceptionApps []string, sen
 	}
 }
 
-func (h *udpHandler) handleInput(conn core.UDPConn, pc net.PacketConn) {
+func (h *udpHandler) handleInput(conn core.UDPConn, pc *net.UDPConn) {
 	buf := core.NewBytes(core.BufSize)
 
 	defer func() {
@@ -50,7 +50,7 @@ func (h *udpHandler) handleInput(conn core.UDPConn, pc net.PacketConn) {
 
 	for {
 		pc.SetDeadline(time.Now().Add(h.timeout))
-		n, addr, err := pc.ReadFrom(buf)
+		n, addr, err := pc.ReadFromUDP(buf)
 		if err != nil {
 			return
 		}
@@ -62,7 +62,7 @@ func (h *udpHandler) handleInput(conn core.UDPConn, pc net.PacketConn) {
 	}
 }
 
-func (h *udpHandler) Connect(conn core.UDPConn, target net.Addr) error {
+func (h *udpHandler) Connect(conn core.UDPConn, target *net.UDPAddr) error {
 	localHost, localPortStr, _ := net.SplitHostPort(conn.LocalAddr().String())
 	localPortInt, _ := strconv.Atoi(localPortStr)
 	cmd, err := lsof.GetCommandNameBySocket("udp", localHost, uint16(localPortInt))
@@ -93,7 +93,7 @@ func (h *udpHandler) Connect(conn core.UDPConn, target net.Addr) error {
 	}
 }
 
-func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr net.Addr) error {
+func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr *net.UDPAddr) error {
 	h.Lock()
 	defer h.Unlock()
 

--- a/proxy/direct/tcp.go
+++ b/proxy/direct/tcp.go
@@ -34,8 +34,8 @@ func (h *tcpHandler) handleOutput(conn net.Conn, output io.WriteCloser) {
 	io.Copy(output, conn)
 }
 
-func (h *tcpHandler) Handle(conn net.Conn, target net.Addr) error {
-	c, err := net.Dial("tcp", target.String())
+func (h *tcpHandler) Handle(conn net.Conn, target *net.TCPAddr) error {
+	c, err := net.DialTCP("tcp", nil, target)
 	if err != nil {
 		return err
 	}

--- a/proxy/dnsfallback/udp.go
+++ b/proxy/dnsfallback/udp.go
@@ -26,18 +26,14 @@ func NewUDPHandler() core.UDPConnHandler {
 	return &udpHandler{}
 }
 
-func (h *udpHandler) Connect(conn core.UDPConn, target net.Addr) error {
-	udpAddr, ok := target.(*net.UDPAddr)
-	if !ok {
-		return errors.New("Unsupported address type")
-	}
+func (h *udpHandler) Connect(conn core.UDPConn, udpAddr *net.UDPAddr) error {
 	if udpAddr.Port != dns.COMMON_DNS_PORT {
 		return errors.New("Cannot handle non-DNS packet")
 	}
 	return nil
 }
 
-func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr net.Addr) error {
+func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr *net.UDPAddr) error {
 	if len(data) < dnsHeaderLength {
 		return errors.New("Received malformed DNS query")
 	}

--- a/proxy/echo/tcp.go
+++ b/proxy/echo/tcp.go
@@ -20,7 +20,7 @@ func (h *tcpHandler) echoBack(conn net.Conn) {
 	io.Copy(conn, conn)
 }
 
-func (h *tcpHandler) Handle(conn net.Conn, target net.Addr) error {
+func (h *tcpHandler) Handle(conn net.Conn, target *net.TCPAddr) error {
 	go h.echoBack(conn)
 	return nil
 }

--- a/proxy/echo/udp.go
+++ b/proxy/echo/udp.go
@@ -14,11 +14,11 @@ func NewUDPHandler() core.UDPConnHandler {
 	return &udpHandler{}
 }
 
-func (h *udpHandler) Connect(conn core.UDPConn, target net.Addr) error {
+func (h *udpHandler) Connect(conn core.UDPConn, target *net.UDPAddr) error {
 	return nil
 }
 
-func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr net.Addr) error {
+func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr *net.UDPAddr) error {
 	// Dispatch to another goroutine, otherwise will result in deadlock.
 	payload := append([]byte(nil), data...)
 	go func(b []byte) {

--- a/proxy/redirect/tcp.go
+++ b/proxy/redirect/tcp.go
@@ -75,7 +75,7 @@ func (h *tcpHandler) handleOutput(conn net.Conn, output io.WriteCloser) {
 	io.Copy(output, conn)
 }
 
-func (h *tcpHandler) Handle(conn net.Conn, target net.Addr) error {
+func (h *tcpHandler) Handle(conn net.Conn, target *net.TCPAddr) error {
 	c, err := net.Dial("tcp", h.target)
 	if err != nil {
 		return err

--- a/proxy/redirect/udp.go
+++ b/proxy/redirect/udp.go
@@ -53,7 +53,7 @@ func (h *udpHandler) fetchUDPInput(conn core.UDPConn, pc *net.UDPConn) {
 	}
 }
 
-func (h *udpHandler) Connect(conn core.UDPConn, target net.Addr) error {
+func (h *udpHandler) Connect(conn core.UDPConn, target *net.UDPAddr) error {
 	bindAddr := &net.UDPAddr{IP: nil, Port: 0}
 	pc, err := net.ListenUDP("udp", bindAddr)
 	if err != nil {
@@ -70,7 +70,7 @@ func (h *udpHandler) Connect(conn core.UDPConn, target net.Addr) error {
 	return nil
 }
 
-func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr net.Addr) error {
+func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr *net.UDPAddr) error {
 	h.Lock()
 	pc, ok1 := h.udpConns[conn]
 	tgtAddr, ok2 := h.udpTargetAddrs[conn]

--- a/proxy/shadowsocks/udp.go
+++ b/proxy/shadowsocks/udp.go
@@ -88,7 +88,7 @@ func (h *udpHandler) fetchUDPInput(conn core.UDPConn, input net.PacketConn) {
 	}
 }
 
-func (h *udpHandler) Connect(conn core.UDPConn, target net.Addr) error {
+func (h *udpHandler) Connect(conn core.UDPConn, target *net.UDPAddr) error {
 	pc, err := net.ListenPacket("udp", "")
 	if err != nil {
 		return err
@@ -105,17 +105,13 @@ func (h *udpHandler) Connect(conn core.UDPConn, target net.Addr) error {
 	return nil
 }
 
-func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr net.Addr) error {
+func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr *net.UDPAddr) error {
 	h.Lock()
 	pc, ok1 := h.conns[conn]
 	h.Unlock()
 
-	if h.fakeDns != nil {
-		_, port, err := net.SplitHostPort(addr.String())
-		if err != nil {
-			panic("impossible error")
-		}
-		if port == strconv.Itoa(dns.COMMON_DNS_PORT) {
+	if addr.Port == dns.COMMON_DNS_PORT {
+		if h.fakeDns != nil {
 			resp, err := h.fakeDns.GenerateFakeResponse(data)
 			if err == nil {
 				_, err = conn.WriteFrom(resp, addr)
@@ -126,16 +122,10 @@ func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr net.Addr) er
 				return nil
 			}
 		}
-	}
 
-	if h.dnsCache != nil {
-		_, port, err := net.SplitHostPort(addr.String())
-		if err != nil {
-			panic("impossible error")
-		}
-		if port == strconv.Itoa(dns.COMMON_DNS_PORT) {
+		if h.dnsCache != nil {
 			if answer := h.dnsCache.Query(data); answer != nil {
-				_, err = conn.WriteFrom(answer, addr)
+				_, err := conn.WriteFrom(answer, addr)
 				if err != nil {
 					return errors.New(fmt.Sprintf("cache dns answer failed: %v", err))
 				}
@@ -147,23 +137,17 @@ func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr net.Addr) er
 
 	if ok1 {
 		// Replace with a domain name if target address IP is a fake IP.
-		host, port, err := net.SplitHostPort(addr.String())
-		if err != nil {
-			log.Errorf("error when split host port %v", err)
+		var targetHost string
+		if h.fakeDns != nil && h.fakeDns.IsFakeIP(addr.IP) {
+			targetHost = h.fakeDns.QueryDomain(addr.IP)
+		} else {
+			targetHost = addr.IP.String()
 		}
-		var targetHost string = host
-		if h.fakeDns != nil {
-			if ip := net.ParseIP(host); ip != nil {
-				if h.fakeDns.IsFakeIP(ip) {
-					targetHost = h.fakeDns.QueryDomain(ip)
-				}
-			}
-		}
-		dest := fmt.Sprintf("%s:%s", targetHost, port)
+		dest := net.JoinHostPort(targetHost, strconv.Itoa(addr.Port))
 
 		buf := append([]byte{0, 0, 0}, sssocks.ParseAddr(dest)...)
 		buf = append(buf, data[:]...)
-		_, err = pc.WriteTo(buf[3:], h.remoteAddr)
+		_, err := pc.WriteTo(buf[3:], h.remoteAddr)
 		if err != nil {
 			h.Close(conn)
 			return errors.New(fmt.Sprintf("write remote failed: %v", err))

--- a/proxy/v2ray/tcp.go
+++ b/proxy/v2ray/tcp.go
@@ -43,7 +43,7 @@ func NewTCPHandler(ctx context.Context, instance *vcore.Instance) core.TCPConnHa
 	}
 }
 
-func (h *tcpHandler) Handle(conn net.Conn, target net.Addr) error {
+func (h *tcpHandler) Handle(conn net.Conn, target *net.TCPAddr) error {
 	dest := vnet.DestinationFromAddr(target)
 	sid := vsession.NewID()
 	ctx := vsession.ContextWithID(h.ctx, sid)

--- a/proxy/v2ray/udp.go
+++ b/proxy/v2ray/udp.go
@@ -25,7 +25,7 @@ type udpConnEntry struct {
 	// all data receive from V2Ray are coming from the
 	// same remote host, i.e. the `target` that passed
 	// to `Connect`.
-	target net.Addr
+	target *net.UDPAddr
 
 	updater vsignal.ActivityUpdater
 }
@@ -76,7 +76,7 @@ func NewUDPHandler(ctx context.Context, instance *vcore.Instance, timeout time.D
 	}
 }
 
-func (h *udpHandler) Connect(conn core.UDPConn, target net.Addr) error {
+func (h *udpHandler) Connect(conn core.UDPConn, target *net.UDPAddr) error {
 	if target == nil {
 		return errors.New("nil target is not allowed")
 	}
@@ -108,7 +108,7 @@ func (h *udpHandler) Connect(conn core.UDPConn, target net.Addr) error {
 	return nil
 }
 
-func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr net.Addr) error {
+func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr *net.UDPAddr) error {
 	h.Lock()
 	c, ok := h.conns[conn]
 	h.Unlock()


### PR DESCRIPTION
This simplifies proxy implementations by removing unnecessary
type assertions and conversions.