### PR TITLE
Linux: add option to configure TUN device persistence

### DIFF
--- a/cmd/tun2socks/main.go
+++ b/cmd/tun2socks/main.go
@@ -37,6 +37,7 @@ type CmdArgs struct {
 	TunGw       *string
 	TunMask     *string
 	TunDns      *string
+	TunPersist  *bool
 	ProxyType   *string
 	ProxyServer *string
 	ProxyHost   *string
@@ -89,6 +90,7 @@ func main() {
 	args.TunGw = flag.String("tunGw", "10.255.0.1", "TUN interface gateway")
 	args.TunMask = flag.String("tunMask", "255.255.255.0", "TUN interface netmask, it should be a prefixlen (a number) for IPv6 address")
 	args.TunDns = flag.String("tunDns", "8.8.8.8,8.8.4.4", "DNS resolvers for TUN interface (only need on Windows)")
+	args.TunPersist = flag.Bool("tunPersist", false, "Persist TUN interface after the program exits or the last open file descriptor is closed (Linux only)")
 	args.ProxyType = flag.String("proxyType", "socks", "Proxy handler type")
 	args.LogLevel = flag.String("loglevel", "info", "Logging level. (debug, info, warn, error, none)")
 
@@ -124,7 +126,7 @@ func main() {
 
 	// Open the tun device.
 	dnsServers := strings.Split(*args.TunDns, ",")
-	tunDev, err := tun.OpenTunDevice(*args.TunName, *args.TunAddr, *args.TunGw, *args.TunMask, dnsServers)
+	tunDev, err := tun.OpenTunDevice(*args.TunName, *args.TunAddr, *args.TunGw, *args.TunMask, dnsServers, *args.TunPersist)
 	if err != nil {
 		log.Fatalf("failed to open tun device: %v", err)
 	}

--- a/tun/tun_darwin.go
+++ b/tun/tun_darwin.go
@@ -30,7 +30,7 @@ func isIPv6(ip net.IP) bool {
 	return false
 }
 
-func OpenTunDevice(name, addr, gw, mask string, dnsServers []string) (io.ReadWriteCloser, error) {
+func OpenTunDevice(name, addr, gw, mask string, dnsServers []string, persist bool) (io.ReadWriteCloser, error) {
 	tunDev, err := water.New(water.Config{
 		DeviceType: water.TUN,
 	})

--- a/tun/tun_linux.go
+++ b/tun/tun_linux.go
@@ -6,11 +6,12 @@ import (
 	"github.com/songgao/water"
 )
 
-func OpenTunDevice(name, addr, gw, mask string, dnsServers []string) (io.ReadWriteCloser, error) {
+func OpenTunDevice(name, addr, gw, mask string, dnsServers []string, persist bool) (io.ReadWriteCloser, error) {
 	cfg := water.Config{
 		DeviceType: water.TUN,
 	}
 	cfg.Name = name
+	cfg.Persist = persist
 	tunDev, err := water.New(cfg)
 	if err != nil {
 		return nil, err

--- a/tun/tun_windows.go
+++ b/tun/tun_windows.go
@@ -157,7 +157,7 @@ func getTuntapComponentId(ifaceName string) (string, string, error) {
 	return "", "", errors.New("not found component id")
 }
 
-func OpenTunDevice(name, addr, gw, mask string, dns []string) (io.ReadWriteCloser, error) {
+func OpenTunDevice(name, addr, gw, mask string, dns []string, persist bool) (io.ReadWriteCloser, error) {
 	componentId, devName, err := getTuntapComponentId(name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get component ID: %v", err)


### PR DESCRIPTION
* On Linux, when the TUN device is opened, the water package [unconditionally calls](https://github.com/songgao/water/blob/fd331bda3f4bbc9aad07ccd4bd2abaa1e363a852/syscalls_linux.go#L78) `ioctl TUNSETPERSIST` with a value specified in `water.Config`. When `TUNSETPERSIST` is disabled, the system will  delete the TUN device when the last open file descriptor is called.
* This change, allows the persistance behavior to be controlled form the command line in a backwards compatible way.
* Additionally, it enables consumers of the `github.com/eycorsican/go-tun2socks/tun` package to decouple the lifecycle of the TUN device and go-tun2socks.