### PR TITLE
解决任天堂Switch无法建立联机游戏

### DIFF
--- a/core/udp_conn.go
+++ b/core/udp_conn.go
@@ -46,7 +46,7 @@ func newUDPConn(pcb *C.struct_udp_pcb, handler UDPConnHandler, localIP C.ip_addr
 		localIP:   localIP,
 		localPort: localPort,
 		state:     udpConnecting,
-		pending:   make(chan *udpPacket, 1), // To hold the first packet on the connection
+		pending:   make(chan *udpPacket, 64), // To hold the early packets on the connection
 	}
 
 	go func() {
@@ -68,6 +68,7 @@ func newUDPConn(pcb *C.struct_udp_pcb, handler UDPConnHandler, localIP C.ip_addr
 					}
 					continue DrainPending
 				default:
+					conn.pending = nil
 					break DrainPending
 				}
 			}


### PR DESCRIPTION
Switch在建立联机游戏的时候，会直接发近20个udp包出去，现在的代码只能cache一个包，其他包都丢了，导致连接建立失败。网络测试经常A和F之间来回跳。

增大`conn.pending`的缓冲可以解决，用完了设为nil，保证它能被GC。